### PR TITLE
Remove unused variable in function readBytes

### DIFF
--- a/src/SparkFunSX1509.cpp
+++ b/src/SparkFunSX1509.cpp
@@ -737,8 +737,6 @@ unsigned int SX1509::readWord(byte registerAddress)
 //	- No return value.
 void SX1509::readBytes(byte firstRegisterAddress, byte * destination, byte length)
 {
-	byte readValue;
-
 	Wire.beginTransmission(deviceAddress);
 	Wire.write(firstRegisterAddress);
 	Wire.endTransmission();


### PR DESCRIPTION
The results of Wire.read() are directly placed into an array passed as a function variable. The variable may have been used previously, but now is not.