### PR TITLE
Correct case of reference link in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -52,6 +52,6 @@ SOFTWARE_RESET	LITERAL1
 HARDWARE_RESET	LITERAL1
 
 #######################################
-# Blue Constants (LITERAL2, constants, RESERVED_WORD_2)
+# Blue Constants (LITERAL2, Constants, RESERVED_WORD_2)
 #######################################
-ANALOG_OUTPUT	LITERAL2	constants	RESERVED_WORD_2
+ANALOG_OUTPUT	LITERAL2	Constants	RESERVED_WORD_2


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match the case of any existing reference pages results in a "Could not open the URL" error on a case-sensitive OS like Linux.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format