### PR TITLE
Commented RECEIVE_TIMEOUT_VALUE as variable seems unused

### DIFF
--- a/src/SparkFunSX1509.cpp
+++ b/src/SparkFunSX1509.cpp
@@ -544,7 +544,7 @@ void SX1509::debounceTime(uint8_t time)
 	uint8_t configValue = 0;
 	// We'll check for the highest set bit position,
 	// and use that for debounceConfig
-	for (uint8_t i = 7; i >= 0; i--)
+	for (int8_t i = 7; i >= 0; i--)
 	{
 		if (time & (1 << i))
 		{

--- a/src/SparkFunSX1509.cpp
+++ b/src/SparkFunSX1509.cpp
@@ -750,7 +750,7 @@ uint16_t SX1509::readWord(uint8_t registerAddress)
 	uint16_t readValue;
 	uint16_t msb, lsb;
 	// Commented the line as variable seems unused; 
-	uint16_t timeout = RECEIVE_TIMEOUT_VALUE * 2;
+	//uint16_t timeout = RECEIVE_TIMEOUT_VALUE * 2;
 
 	_i2cPort->beginTransmission(deviceAddress);
 	_i2cPort->write(registerAddress);

--- a/src/SparkFunSX1509.cpp
+++ b/src/SparkFunSX1509.cpp
@@ -727,7 +727,8 @@ uint8_t SX1509::calculateSlopeRegister(uint8_t ms, uint8_t onIntensity, uint8_t 
 uint8_t SX1509::readByte(uint8_t registerAddress)
 {
 	uint8_t readValue;
-	uint16_t timeout = RECEIVE_TIMEOUT_VALUE;
+	// Commented the line as variable seems unused; 
+	//uint16_t timeout = RECEIVE_TIMEOUT_VALUE;
 
 	_i2cPort->beginTransmission(deviceAddress);
 	_i2cPort->write(registerAddress);
@@ -748,6 +749,7 @@ uint16_t SX1509::readWord(uint8_t registerAddress)
 {
 	uint16_t readValue;
 	uint16_t msb, lsb;
+	// Commented the line as variable seems unused; 
 	uint16_t timeout = RECEIVE_TIMEOUT_VALUE * 2;
 
 	_i2cPort->beginTransmission(deviceAddress);


### PR DESCRIPTION
The variables 'RECEIVE_TIMEOUT_VALUE' in SX1509::readByte & SX1509::readWord seem to be unused. Commented.