### PR TITLE
Fix reset to use system definition of digital write

### DIFF
--- a/src/SparkFunSX1509.cpp
+++ b/src/SparkFunSX1509.cpp
@@ -93,10 +93,10 @@ void SX1509::reset(bool hardware)
 			writeByte(REG_MISC, regMisc);
 		}
 		// Reset the SX1509, the pin is active low
-		pinMode(pinReset, OUTPUT);	  // set reset pin as output
-		digitalWrite(pinReset, LOW);  // pull reset pin low
+		::pinMode(pinReset, OUTPUT);	  // set reset pin as output
+		::digitalWrite(pinReset, LOW);  // pull reset pin low
 		delay(1);					  // Wait for the pin to settle
-		digitalWrite(pinReset, HIGH); // pull reset pin back high
+		::digitalWrite(pinReset, HIGH); // pull reset pin back high
 	}
 	else
 	{
@@ -506,10 +506,10 @@ void SX1509::sync(void)
 	}
 
 	// Toggle nReset pin to sync LED timers
-	pinMode(pinReset, OUTPUT);	  // set reset pin as output
-	digitalWrite(pinReset, LOW);  // pull reset pin low
+	::pinMode(pinReset, OUTPUT);	  // set reset pin as output
+	::digitalWrite(pinReset, LOW);  // pull reset pin low
 	delay(1);					  // Wait for the pin to settle
-	digitalWrite(pinReset, HIGH); // pull reset pin back high
+	::digitalWrite(pinReset, HIGH); // pull reset pin back high
 
 	// Return nReset to POR functionality
 	writeByte(REG_MISC, (regMisc & ~(1 << 2)));


### PR DESCRIPTION
Within init(), reset(1) is called if a hardware reset is provided:
}
if (hardware) {
// Check if bit 2 of REG_MISC is set
// if so nReset will not issue a POR, we'll need to clear that bit first
byte regMisc = readByte(REG_MISC);
if (regMisc & (1 << 2)) {
regMisc &= ~(1 << 2);
writeByte(REG_MISC, regMisc);
}
**// Reset the SX1509, the pin is active low
pinMode(pinReset, OUTPUT); // set reset pin as output
digitalWrite(pinReset, LOW); // pull reset pin low
delay(1); // Wait for the pin to settle
digitalWrite(pinReset, HIGH); // pull reset pin back high
}**

The bolded lines of code above assume your Arduino will reset the io expander using the gpio assigned to pinReset. Problem is that this library actually calls SX1509::digitalWrite() instead of the Arduino digitalWrite. So the hardware reset never occurs